### PR TITLE
Address several fixes around multiprocessing, LOD and typos

### DIFF
--- a/lexcube/lexcube_server/src/tile_server.py
+++ b/lexcube/lexcube_server/src/tile_server.py
@@ -785,8 +785,8 @@ class ParameterMetadataParser:
         z_samples_target = 50
         z_sampling_step = max(1, math.floor(float(last_time_slice - first_time_slice + 1) / z_samples_target)) if approximate_only else 1
         z_samples_actual = math.ceil(float(last_time_slice - first_time_slice + 1) / z_sampling_step)
-        minimum_value = np.Infinity
-        maximum_value = -np.Infinity
+        minimum_value = np.inf
+        maximum_value = -np.inf
         observations = 0
         local_1quantiles = []
         local_99quantiles = []

--- a/lexcube/lexcube_server/src/tile_server.py
+++ b/lexcube/lexcube_server/src/tile_server.py
@@ -387,10 +387,12 @@ def sample_data_array_2d(data, sample_factor):
     return np.stack([s[i] for i in range(len(s))]) 
 
 def calculate_max_lod(tile_size: int, dims: list[int]):
+    if tile_size <= 0 or len(dims) == 0 or min(dims) <= 0 or max(dims) <= 0:
+        return 0
     desired_max_lod = math.ceil(-math.log2(tile_size / max(dims)))
     largest_lod_possible_from_dims = math.floor(math.log2(min(dims)))
     largest_lod_possible_from_tile_size = math.floor(math.log2(tile_size))
-    return min(desired_max_lod, largest_lod_possible_from_dims, largest_lod_possible_from_tile_size)
+    return max(0, min(desired_max_lod, largest_lod_possible_from_dims, largest_lod_possible_from_tile_size))
 
 def patch_data(data: np.ndarray, dataset_id: str, parameter: str, dataset_config: DatasetConfig = None) -> np.ndarray:
     if len(data.shape) == 4: # RGB data does not need patching
@@ -1032,9 +1034,12 @@ class Dataset:
             
 
     def calculate_max_lod(self, tile_size: int):
-        desired_max_lod = math.ceil(-math.log2(tile_size / max([self.meta_data.z_max, self.meta_data.y_max, self.meta_data.x_max])))
-        largest_lod_possible = math.floor(math.log2(min([self.meta_data.z_max, self.meta_data.y_max, self.meta_data.x_max])))
-        return min(desired_max_lod, largest_lod_possible)
+        dims = [self.meta_data.z_max, self.meta_data.y_max, self.meta_data.x_max]
+        if tile_size <= 0 or min(dims) <= 0 or max(dims) <= 0:
+            return 0
+        desired_max_lod = math.ceil(-math.log2(tile_size / max(dims)))
+        largest_lod_possible = math.floor(math.log2(min(dims)))
+        return max(0, min(desired_max_lod, largest_lod_possible))
 
     def generate_block_file_indices(self):
         self.block_2d_contents_by_dim_and_lod = []

--- a/lexcube/lexcube_server/src/tile_server.py
+++ b/lexcube/lexcube_server/src/tile_server.py
@@ -1727,7 +1727,7 @@ class TileServer:
         threads = self.config.pre_generation_threads
         print(f"* Discover metadata for dataset {dataset.id} (using {threads} threads)")
         metadata = {}
-        with multiprocessing.Pool(threads) as pool:
+        with multiprocessing.get_context("spawn").Pool(threads) as pool:
             metadatas = pool.starmap(ParameterMetadataParser(self.config, dataset.min_max_values_approximate_only, dataset.dataset_config.dataset_path, dataset.id).discover_metadata_for_parameter, [(dataset.parameter_metadata.get(p), p) for p in dataset.real_parameters + dataset.composite_rgb_parameters])
             for m in metadatas:
                 metadata[m.name] = m.to_dict()

--- a/lexcube/tests/test_lod_clamping.py
+++ b/lexcube/tests/test_lod_clamping.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from lexcube.cube3d import Cube3DWidget
+from lexcube.lexcube_server.src.tile_server import calculate_max_lod
+
+
+def test_calculate_max_lod_never_negative_for_small_shapes():
+    assert calculate_max_lod(256, [10, 20, 30]) == 0
+    assert calculate_max_lod(256, [1, 1, 1]) == 0
+
+
+def test_calculate_max_lod_handles_invalid_dimensions_gracefully():
+    assert calculate_max_lod(256, [0, 20, 30]) == 0
+    assert calculate_max_lod(0, [10, 20, 30]) == 0
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (10, 20, 30),
+        (1, 1, 1),
+        (4, 8, 16),
+    ],
+)
+def test_widget_metadata_lods_for_small_numpy_cubes(shape):
+    widget = Cube3DWidget(np.random.rand(*shape).astype("float32"))
+    metadata = widget.api_metadata["/api/datasets/default"]
+
+    assert metadata["max_lod_2d"] == 0
+    assert metadata["max_lod_3d"] == 0
+
+
+def test_widget_metadata_lods_are_non_negative_for_small_numpy_data():
+    widget = Cube3DWidget(np.random.rand(10, 20, 30).astype("float32"))
+    metadata = widget.api_metadata["/api/datasets/default"]
+
+    assert metadata["max_lod_2d"] >= 0
+    assert metadata["max_lod_3d"] >= 0
+
+
+def test_widget_metadata_lods_for_small_xarray_cube():
+    time = np.array("2000-01-01", dtype="datetime64[D]") + np.arange(10)
+    lat = np.linspace(-90.0, 90.0, 20)
+    lon = np.linspace(-180.0, 180.0, 30)
+    data = xr.DataArray(
+        np.random.rand(10, 20, 30).astype("float32"),
+        dims=("time", "lat", "lon"),
+        coords={"time": time, "lat": lat, "lon": lon},
+        name="var",
+    )
+    widget = Cube3DWidget(data)
+    metadata = widget.api_metadata["/api/datasets/default"]
+
+    assert metadata["max_lod_2d"] == 0
+    assert metadata["max_lod_3d"] == 0

--- a/src/lexcube-client/src/client/interaction.ts
+++ b/src/lexcube-client/src/client/interaction.ts
@@ -3687,19 +3687,23 @@ class CubeInteraction {
     }
 
     getMaxLod3d() {
-        return Math.min(this.selectedCubeMetadata.max_lod_3d, MAXIMUM_SUPPORTED_LOD);
+        const requestedMaxLod = this.selectedCubeMetadata.max_lod_3d;
+        if (requestedMaxLod === undefined || requestedMaxLod === null || isNaN(requestedMaxLod)) {
+            return 0;
+        }
+        return Math.max(0, Math.min(requestedMaxLod, MAXIMUM_SUPPORTED_LOD));
     }
 
     getMaxLod2d() {
         let requestedMaxLod = this.selectedCubeMetadata.max_lod_2d;
-        if (!requestedMaxLod) {
+        if (requestedMaxLod === undefined || requestedMaxLod === null || isNaN(requestedMaxLod)) {
             const largestDim = this.cubeDimensions.totalSize().clone().toArray().reduce((a, b) => Math.max(a, b), 0);
             const calculatedMaxLod = Math.max(Math.floor(Math.log2(largestDim / TILE_SIZE_2D)), 0);
             this.selectedCubeMetadata.max_lod_2d = calculatedMaxLod;
             requestedMaxLod = calculatedMaxLod;
             console.warn("Cube metadata missing max_lod_2d, setting to", requestedMaxLod, "based on largest dimension size", largestDim);
         }
-        return Math.min(requestedMaxLod, MAXIMUM_SUPPORTED_LOD);
+        return Math.max(0, Math.min(requestedMaxLod, MAXIMUM_SUPPORTED_LOD));
     }
 
     

--- a/src/lexcube-client/src/client/rendering.ts
+++ b/src/lexcube-client/src/client/rendering.ts
@@ -2491,11 +2491,18 @@ class CubeRendering {
     }
 
     updateTileTextureView3dFromVisibleTiles(visibleTiles: Tile3D[]) {
+        if (visibleTiles.length === 0) {
+            return;
+        }
         const lod = visibleTiles[0].lod;
         const ttv = this.tile3dVolumeRenderedCubeTileTextureViews[lod];
+        if (!ttv) {
+            console.warn("Missing TileTextureView3D for lod", lod);
+            return;
+        }
 
         const ttvCoversAll = visibleTiles.every(t => ttv.containsTile(t))
-        if (!ttvCoversAll || this.tile3dVolumeRenderedCubeTileTextureViews[lod].needsInitialUpdate()) {
+        if (!ttvCoversAll || ttv.needsInitialUpdate()) {
             this.updateTileTextureView3D(lod);
         }
     }
@@ -2508,9 +2515,13 @@ class CubeRendering {
             }
             const lod = faceTiles[0].lod;
             const ttv = this.tile2dFaceRenderedCubeTileTextureViews[face][lod];
+            if (!ttv) {
+                console.warn("Missing TileTextureView2D for face/lod", face, lod);
+                continue;
+            }
 
             const ttvCoversAll = faceTiles.every(t => ttv.containsTile(t))
-            if (!ttvCoversAll || this.tile2dFaceRenderedCubeTileTextureViews[face][lod].needsInitialUpdate()) {
+            if (!ttvCoversAll || ttv.needsInitialUpdate()) {
                 this.updateTileTextureView2d(face, lod);
             }
         }
@@ -2525,8 +2536,11 @@ class CubeRendering {
         }
     }
 
-    possibleToRenderLod3d(lod: number) {    
+    possibleToRenderLod3d(lod: number) {
         const ttv = this.tile3dVolumeRenderedCubeTileTextureViews[lod];
+        if (!ttv) {
+            return false;
+        }
         return ttv.possibleToRender(this.context.interaction.cubeSelection.getDisplaySizeVector3d());
     }
 
@@ -2575,11 +2589,13 @@ class CubeRendering {
     }
 
     getTileTextureView2dSizeInTiles(face: number, lod: number) {
-        return this.tile2dFaceRenderedCubeTileTextureViews[face][lod].getSizeInTiles();
+        const ttv = this.tile2dFaceRenderedCubeTileTextureViews[face][lod];
+        return ttv ? ttv.getSizeInTiles() : new Vector2(0, 0);
     }
 
     getTileTextureView2dOffsetInTiles(face: number, lod: number) {
-        return this.tile2dFaceRenderedCubeTileTextureViews[face][lod].getOffsetInTiles();
+        const ttv = this.tile2dFaceRenderedCubeTileTextureViews[face][lod];
+        return ttv ? ttv.getOffsetInTiles() : new Vector2(0, 0);
     }
 
     getTileTextureView3dSize(lod: number) {
@@ -2587,15 +2603,17 @@ class CubeRendering {
             return this.blockBasedRenderPasses[this.blockBasedRenderPassCurrent].tileTextureView.getSizeInTiles();
         }
         const ttv = this.tile3dVolumeRenderedCubeTileTextureViews[lod];
-        return ttv.getSizeInTiles();
+        return ttv ? ttv.getSizeInTiles() : new Vector3(0, 0, 0);
     }
 
     tileContainedInTileTextureView2d(tile: Tile2D, offsetOverride?: Vector2) {
-        return this.tile2dFaceRenderedCubeTileTextureViews[tile.face][tile.lod].containsTile(tile, offsetOverride);
+        const ttv = this.tile2dFaceRenderedCubeTileTextureViews[tile.face][tile.lod];
+        return ttv ? ttv.containsTile(tile, offsetOverride) : false;
     }
 
     tileContainedInTileTextureView3d(tile: Tile3D, offsetOverride?: Vector3) {
-        return this.tile3dVolumeRenderedCubeTileTextureViews[tile.lod].containsTile(tile, offsetOverride);
+        const ttv = this.tile3dVolumeRenderedCubeTileTextureViews[tile.lod];
+        return ttv ? ttv.containsTile(tile, offsetOverride) : false;
     }
 
     getTileTextureView3dOffset(lod: number) {

--- a/src/lexcube-client/src/client/ui/colormap-ui.ts
+++ b/src/lexcube-client/src/client/ui/colormap-ui.ts
@@ -286,7 +286,7 @@ class ColormapUIManager {
     }
 
     selectArbitraryLinear(parameterIndex: number) {
-        const names = ["viridian", "algae", "deep", "dense", "haline", "ice", "speed", "tempo", "turbid"];
+        const names = ["viridis", "algae", "deep", "dense", "haline", "ice", "speed", "tempo", "turbid"];
         this.selectByName(names[parameterIndex % names.length]);
     }
 


### PR DESCRIPTION
This pull request focuses on improving robustness and correctness in both the Python backend (`tile_server.py`) and the TypeScript frontend, particularly around handling Level of Detail (LOD) calculations and rendering logic. It also introduces comprehensive tests to ensure LOD values remain non-negative and that edge cases are handled gracefully. The most important changes are summarized below:

### Backend (Python) - LOD Calculation and Multiprocessing

* Improved `calculate_max_lod` in `tile_server.py` to always return non-negative values and handle invalid or small dimension inputs gracefully, preventing potential negative LODs or errors. [[1]](diffhunk://#diff-1587ecbfc8183b205863ef856ac876efea063ce56116087316aca5ef9705d5cdR390-R395) [[2]](diffhunk://#diff-1587ecbfc8183b205863ef856ac876efea063ce56116087316aca5ef9705d5cdL1035-R1042)
* Changed multiprocessing pool creation to use the "spawn" context, improving compatibility and stability across platforms.
* Standardized usage of `np.inf` and `-np.inf` for numerical min/max initialization, replacing the deprecated `np.Infinity`.

### Backend (Python) - Testing

* Added a new test suite `test_lod_clamping.py` to verify that LOD calculations never return negative values and that widget metadata is consistent for small or invalid cube shapes.

### Frontend (TypeScript) - LOD and Rendering Robustness

* Updated LOD retrieval methods in `CubeInteraction` to ensure returned values are always non-negative and handle missing or invalid metadata, preventing rendering issues.
* Enhanced `CubeRendering` methods to check for undefined or missing `TileTextureView` objects before accessing them, adding safety checks and fallback values to avoid runtime errors and improve logging for missing resources. [[1]](diffhunk://#diff-beb85c0d8191cba14fd3bd3e14930cf6e68fc8c24074638ea72dc938d6878ea7R2494-R2505) [[2]](diffhunk://#diff-beb85c0d8191cba14fd3bd3e14930cf6e68fc8c24074638ea72dc938d6878ea7R2518-R2524) [[3]](diffhunk://#diff-beb85c0d8191cba14fd3bd3e14930cf6e68fc8c24074638ea72dc938d6878ea7R2541-R2543) [[4]](diffhunk://#diff-beb85c0d8191cba14fd3bd3e14930cf6e68fc8c24074638ea72dc938d6878ea7L2578-R2616)

### Frontend (TypeScript) - UI Improvements

* Fixed a typo in the colormap selection list, changing `"viridian"` to the correct `"viridis"` name.